### PR TITLE
Add alias "microsoftedge" for "edge" emoji

### DIFF
--- a/img-buildkite-64.json
+++ b/img-buildkite-64.json
@@ -47,7 +47,7 @@
     "name": "edge",
     "image": "img-buildkite-64/edge.png",
     "category": "Buildkite",
-    "aliases": []
+    "aliases": ["microsoftedge"]
   },
   {
     "name": "clojure",


### PR DESCRIPTION
Saucelabs and other services identify "edge" via "microsoftedge" - for dynamic pipelines it is helpful if we could pick that up automatically.