### PR TITLE
Add :js: as an alias for :javascript:

### DIFF
--- a/img-buildkite-64.json
+++ b/img-buildkite-64.json
@@ -793,7 +793,7 @@
     "name": "javascript",
     "image": "img-buildkite-64/javascript.png",
     "category": "Buildkite",
-    "aliases": []
+    "aliases": ["js"]
   },
   {
     "name": "typescript",


### PR DESCRIPTION
I keep using `:js:` instead of `:javascript:` expecting it to work — should it?