### PR TITLE
Add an alias for the AWS emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Emoji | Aliases
 <img src="img-buildkite-64/swift.png" width="20" height="20" alt="swift"/> | `:swift:`
 <img src="img-buildkite-64/graphql.png" width="20" height="20" alt="graphql"/> | `:graphql:`
 <img src="img-buildkite-64/cogops.png" width="20" height="20" alt="cogops"/> | `:cogops:`
-<img src="img-buildkite-64/aws.png" width="20" height="20" alt="aws"/> | `:aws:`
+<img src="img-buildkite-64/aws.png" width="20" height="20" alt="aws"/> | `:aws:, :amazon-aws:`
 <img src="img-buildkite-64/mocha.png" width="20" height="20" alt="mocha"/> | `:mocha:`
 <img src="img-buildkite-64/rails.png" width="20" height="20" alt="rails"/> | `:rails:`
 <img src="img-buildkite-64/phoenix.png" width="20" height="20" alt="phoenix"/> | `:phoenix:`

--- a/all_emoji_names.txt
+++ b/all_emoji_names.txt
@@ -27,6 +27,7 @@ alien
 allthethings
 amazon-apigateway
 amazon-athena
+amazon-aws
 amazon-chime
 amazon-clouddirectory
 amazon-cloudsearch

--- a/img-buildkite-64.json
+++ b/img-buildkite-64.json
@@ -1295,7 +1295,9 @@
     "name": "aws",
     "image": "img-buildkite-64/aws.png",
     "category": "Buildkite",
-    "aliases": []
+    "aliases": [
+      "amazon-aws"
+    ]
   },
   {
     "name": "mocha",


### PR DESCRIPTION
It'd be nice to have an alias for the AWS emoji as `:aws:` is in all ARNs so it can make things look strange if you're sending alerts/info to Slack