### PR TITLE
add rake to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'emoji_regex', '~> 3.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     emoji_regex (3.2.2)
+    rake (13.0.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   emoji_regex (~> 3.2.2)
+  rake
 
 BUNDLED WITH
    2.2.5


### PR DESCRIPTION
We have some rake tasks for managing the vendored emoji, and I was having trouble with gem activation when using my system install of rake. Adding rake as an explicit dependency in the Gemfile means I can run `bundle exec rake foo` and all is well.