### PR TITLE
Change branch filter to main

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - name: ":shipit:"
     command: ".buildkite/deploy.sh"
-    branches: "master"
+    branches: "main"
     agents:
       queue: "deploy"


### PR DESCRIPTION
Since renaming the default branch to `main`, pipelines haven't actually been running because it was filtering for `master` instead. This fixes that