### PR TITLE
remove renovate config [FDN-517]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
It seems like we've never actually used renovate to update deps in this repo, so I'm following he principal of least privilege and removing the app from the emojis repo.

Now that the app has no access to the repo, we can remove the config file as well.