### PR TITLE
Add :stack_overflow: to aliases for Stack Overflow emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Buildkite emoji will be shown on both light or dark backgrounds, and at a small 
 
 Emoji | Aliases
 ----- | -------
-<img src="img-buildkite-64/stack_overflow.png" width="20" height="20" alt="stack_overflow"/> | `:stackoverflow:`, `:stack-overflow:`
+<img src="img-buildkite-64/stack_overflow.png" width="20" height="20" alt="stack_overflow"/> | `:stack_overflow:`, `:stackoverflow:`, `:stack-overflow:`
 <img src="img-buildkite-64/imperva.png" width="20" height="20" alt="imperva"/> | `:imperva:`
 <img src="img-buildkite-64/deno.png" width="20" height="20" alt="deno"/> | `:deno:`
 <img src="img-buildkite-64/opensearch.png" width="20" height="20" alt="opensearch"/> | `:opensearch:`


### PR DESCRIPTION
When I added this I didn't realize that I should include the standard name in the list of aliases in this table.