### PR TITLE
remove duplicate aliases from img-buildkite-64.json

### DIFF
--- a/img-buildkite-64.json
+++ b/img-buildkite-64.json
@@ -75,7 +75,7 @@
     "name": "ruff",
     "image": "img-buildkite-64/ruff.png",
     "category": "Buildkite",
-    "aliases": ["ruff"]
+    "aliases": []
   },
   {
     "name": "powershell",
@@ -252,13 +252,13 @@
     "name": "garden-io",
     "image": "img-buildkite-64/garden-io.png",
     "category": "Buildkite",
-    "aliases": ["garden-io"]
+    "aliases": []
   },
   {
     "name": "usertesting",
     "image": "img-buildkite-64/usertesting.png",
     "category": "Buildkite",
-    "aliases": ["usertesting"]
+    "aliases": []
   },
   {
     "name": "express",
@@ -323,7 +323,6 @@
     "aliases": [
       "cucumber",
       "cucumber-io",
-      "cucumber-open",
       "cucumberopen",
       "smartbear-cucumberopen"
     ]
@@ -416,25 +415,25 @@
     "name": "esbuild",
     "image": "img-buildkite-64/esbuild.png",
     "category": "Buildkite",
-    "aliases": ["esbuild"]
+    "aliases": []
   },
   {
     "name": "kart",
     "image": "img-buildkite-64/kart.png",
     "category": "Buildkite",
-    "aliases": ["kart"]
+    "aliases": []
   },
   {
     "name": "locust",
     "image": "img-buildkite-64/locust.png",
     "category": "Buildkite",
-    "aliases": ["locust"]
+    "aliases": []
   },
   {
     "name": "gitlab",
     "image": "img-buildkite-64/gitlab.png",
     "category": "Buildkite",
-    "aliases": ["gitlab"]
+    "aliases": []
   },
   {
     "name": "stack_overflow",


### PR DESCRIPTION
When running `rake verify` I noticed that we get some non-fatal errors:

```
    $ rake verify
    WARNING: Ignored duplicate emoji names:
     - :cucumber: (cucumber) refers to 2 emoji
     - :llama: (llama) refers to 2 emoji 
     - :troll: (troll) refers to 2 emoji 
     - :yarn: (yarn) refers to 2 emoji
    ERROR: Unexpected duplicate emoji names:
     - :cucumber-open: (cucumber-open) refers to 2 emoji 
     - :esbuild: (esbuild) refers to 2 emoji 
     - :garden-io: (garden-io) refers to 2 emoji 
     - :gitlab: (gitlab) refers to 2 emoji 
     - :kart: (kart) refers to 2 emoji 
     - :locust: (locust) refers to 2 emoji 
     - :ruff: (ruff) refers to 2 emoji 
     - :usertesting: (usertesting) refers to 2 emoji
```

This fixes all the errors (but not the warnings). In the set of buildkite custom emoji, we only need to provide value(s) for aliases if they're different to the canonical name. Somehow we've ended up with some emojis (like `ruff`) that have an identical alias (`ruff`).