### PR TITLE
Update pipeline queue and role

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,4 +3,7 @@ steps:
     command: ".buildkite/deploy.sh"
     branches: "main"
     agents:
-      queue: "deploy"
+      queue: "elastic-runners"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role-arn: arn:aws:iam::${ROLE_ACCOUNT_ID}:role/pipeline-buildkite-emojis


### PR DESCRIPTION
Historically, we have used the `deploy` queue to manage resources in the production account. These agents run inside the account, and have fairly broad permissions that are used by several pipelines.

Instead of relying on the agents to have the permissions we need, we can use an OIDC assumable role with custom permissions. The benefits being:

   - The role can be tightly scoped to the permissions needed to add emojis
   - The role is only assumable by the main branch of emojis pipeline
   - We can run the deploy steps on lower privilege agents

This pattern was recently used in the https://github.com/buildkite/site/pull/2898.

A new role has been created for `emojis` in https://github.com/buildkite/ops/pull/2149, that has permissions to interact with S3. However, we may need to tweak the permissions to add anything that's found to be missing for sync.

The env var `ROLE_ACCOUNT_ID` has been added in the [pipeline settings](https://buildkite.com/buildkite/emojis/settings/steps).

Once the pipeline is working smoothly, we can remove buildkite/emojis from the allowlist on the deploy agents.
