### PR TITLE
Add :flag-uk: alias to :gb:

### DIFF
--- a/README.md
+++ b/README.md
@@ -4391,7 +4391,7 @@ Emoji | Aliases
 <img src="img-apple-64/1f1ec-1f1eb.png" width="20" height="20" alt="flag-gf"/> | `:flag-gf:`
 <img src="img-apple-64/1f1ec-1f1ea.png" width="20" height="20" alt="flag-ge"/> | `:flag-ge:`
 <img src="img-apple-64/1f1ec-1f1e9.png" width="20" height="20" alt="flag-gd"/> | `:flag-gd:`
-<img src="img-apple-64/1f1ec-1f1e7.png" width="20" height="20" alt="gb"/> | `:gb:`, `:uk:`, `:flag-gb:`
+<img src="img-apple-64/1f1ec-1f1e7.png" width="20" height="20" alt="gb"/> | `:gb:`, `:uk:`, `:flag-gb:`, `:flag-uk:`
 <img src="img-apple-64/1f1ec-1f1e6.png" width="20" height="20" alt="flag-ga"/> | `:flag-ga:`
 <img src="img-apple-64/1f1eb-1f1f7.png" width="20" height="20" alt="fr"/> | `:fr:`, `:flag-fr:`
 <img src="img-apple-64/1f1eb-1f1f4.png" width="20" height="20" alt="flag-fo"/> | `:flag-fo:`

--- a/img-apple-64.json
+++ b/img-apple-64.json
@@ -1350,7 +1350,8 @@
     "unicode": "1F1EC-1F1E7",
     "aliases": [
       "uk",
-      "flag-gb"
+      "flag-gb",
+      "flag-uk"
     ],
     "modifiers": [
 


### PR DESCRIPTION
I have a matrix of different regions, and the UK one is the only one that doesn't follow the pattern. Hopefully this mildly non-standard naming can be accepted given :uk: is already an alias. 😄 
