### PR TITLE
Change the queue emojis deploys run on [PLT-2529]

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: ".buildkite/deploy.sh"
     branches: "main"
     agents:
-      queue: "elastic-runners"
+      queue: "oss-deploy"
     plugins:
       - aws-assume-role-with-web-identity#v1.0.0:
           role-arn: arn:aws:iam::${ROLE_ACCOUNT_ID}:role/pipeline-buildkite-emojis


### PR DESCRIPTION
WI'ev moved this pipeline from the main cluster to the oss-deploy cluster, which runs more isolated agents and is suitable for deploying open source projects.

However, the queue we need to use in this cluster has a different name.