### PR TITLE
Fix image links for the `lightdash` and `istio` emoji

### DIFF
--- a/img-buildkite-64.json
+++ b/img-buildkite-64.json
@@ -1,13 +1,13 @@
 [
   {
     "name": "lightdash",
-    "image": "img-buildkite64/lightdash.png",
+    "image": "img-buildkite-64/lightdash.png",
     "category": "Buildkite",
     "aliases": []
   },
   {
     "name": "istio",
-    "image": "img-buildkite64/istio.png",
+    "image": "img-buildkite-64/istio.png",
     "category": "Buildkite",
     "aliases": []
   },


### PR DESCRIPTION
### Description

This update the image urls for the `lightdash` and `istio` emoji.

Current (broken) links:
https://buildkiteassets.com/emojis/img-buildkite64/lightdash.png
https://buildkiteassets.com/emojis/img-buildkite64/istio.png

Fixed:
https://buildkiteassets.com/emojis/img-buildkite-64/lightdash.png
<img src="https://buildkiteassets.com/emojis/img-buildkite-64/lightdash.png" width=24 />

https://buildkiteassets.com/emojis/img-buildkite-64/istio.png
<img src="https://buildkiteassets.com/emojis/img-buildkite-64/istio.png" width=24 />

### PR checklist

* [x] The image is 64x64 PNG image
* [x] Image is added to `img-buildkite-64` directory
* [x] Image is referenced in `img-buildkite-64.json` file
* [x] Image is referenced in README markdown file
* [x] The image can be hosted by Buildkite and made available in Buildkite UI
