### PR TITLE
Update to use OIDC session tags on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,5 +5,10 @@ steps:
     agents:
       queue: "oss-deploy"
     plugins:
-      - aws-assume-role-with-web-identity#v1.0.0:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::${ROLE_ACCOUNT_ID}:role/pipeline-buildkite-emojis
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch


### PR DESCRIPTION
### Description

Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/ops/pull/3860 to be shipped first.


### PR checklist

N/A 
