### PR TITLE
Update package.json to use a buildkite owned NPM org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "buildkite-emojis",
+  "name": "@buildkite/emojis",
   "version": "2.0.0",
   "description": "Custom emojis supported by Buildkite which you can use in your build pipelines and terminal output.",
   "repository": "https://github.com/buildkite/emojis",


### PR DESCRIPTION
### Description

Only Buildkite organisation members can publish to this NPM name. 

We are not currently intending to publish this package to NPM, but this ensures people would not mistakenly believe we are publishing and download malicious packages from `buildkite-emojis`. 
